### PR TITLE
Esqueleto da adicao da busca por indices secundarios

### DIFF
--- a/MangaManager.pro
+++ b/MangaManager.pro
@@ -13,13 +13,15 @@ SOURCES += \
     main.cpp \
     mainwindow.cpp \
     manga.cpp \
-    mangamanager.cpp
+    mangamanager.cpp \
+    searchmangadialog.cpp
 
 HEADERS += \
     addmangadialog.h \
     mainwindow.h \
     manga.h \
-    mangamanager.h
+    mangamanager.h \
+    searchmangadialog.h
 
 FORMS += \
     mainwindow.ui

--- a/MangaManager.pro.user.76d827e
+++ b/MangaManager.pro.user.76d827e
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE QtCreatorProject>
-<!-- Written by QtCreator 8.0.1, 2024-06-09T19:57:34. -->
+<!-- Written by QtCreator 6.0.2, 2024-05-31T17:56:11. -->
 <qtcreator>
  <data>
   <variable>EnvironmentId</variable>
-  <value type="QByteArray">{57c533da-d5ac-486e-a35b-53863743000d}</value>
+  <value type="QByteArray">{76d827e4-a2df-4dda-8c7f-da15b62474b1}</value>
  </data>
  <data>
   <variable>ProjectExplorer.Project.ActiveTarget</variable>
-  <value type="qlonglong">0</value>
+  <value type="int">0</value>
  </data>
  <data>
   <variable>ProjectExplorer.Project.EditorSettings</variable>
@@ -28,7 +28,7 @@
      <value type="QByteArray" key="CurrentPreferences">QmlJSGlobal</value>
     </valuemap>
    </valuemap>
-   <value type="qlonglong" key="EditorConfiguration.CodeStyle.Count">2</value>
+   <value type="int" key="EditorConfiguration.CodeStyle.Count">2</value>
    <value type="QByteArray" key="EditorConfiguration.Codec">UTF-8</value>
    <value type="bool" key="EditorConfiguration.ConstrainTooltips">false</value>
    <value type="int" key="EditorConfiguration.IndentSize">4</value>
@@ -70,11 +70,14 @@
    <valuemap type="QVariantMap" key="AutoTest.CheckStates"/>
    <value type="int" key="AutoTest.RunAfterBuild">0</value>
    <value type="bool" key="AutoTest.UseGlobal">true</value>
+   <valuelist type="QVariantList" key="ClangCodeModel.CustomCommandLineKey"/>
+   <value type="bool" key="ClangCodeModel.UseGlobalConfig">true</value>
+   <value type="QString" key="ClangCodeModel.WarningConfigId">Builtin.BuildSystem</value>
    <valuemap type="QVariantMap" key="ClangTools">
     <value type="bool" key="ClangTools.AnalyzeOpenFiles">true</value>
     <value type="bool" key="ClangTools.BuildBeforeAnalysis">true</value>
     <value type="QString" key="ClangTools.DiagnosticConfig">Builtin.DefaultTidyAndClazy</value>
-    <value type="int" key="ClangTools.ParallelJobs">2</value>
+    <value type="int" key="ClangTools.ParallelJobs">6</value>
     <valuelist type="QVariantList" key="ClangTools.SelectedDirs"/>
     <valuelist type="QVariantList" key="ClangTools.SelectedFiles"/>
     <valuelist type="QVariantList" key="ClangTools.SuppressedDiagnostics"/>
@@ -86,16 +89,16 @@
   <variable>ProjectExplorer.Project.Target.0</variable>
   <valuemap type="QVariantMap">
    <value type="QString" key="DeviceType">Desktop</value>
-   <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Qt5</value>
-   <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Qt5</value>
-   <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">qt5</value>
-   <value type="qlonglong" key="ProjectExplorer.Target.ActiveBuildConfiguration">0</value>
-   <value type="qlonglong" key="ProjectExplorer.Target.ActiveDeployConfiguration">0</value>
-   <value type="qlonglong" key="ProjectExplorer.Target.ActiveRunConfiguration">0</value>
+   <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Desktop</value>
+   <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Desktop</value>
+   <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">{d24d6469-244e-454d-a72b-050b3fa19e1d}</value>
+   <value type="int" key="ProjectExplorer.Target.ActiveBuildConfiguration">0</value>
+   <value type="int" key="ProjectExplorer.Target.ActiveDeployConfiguration">0</value>
+   <value type="int" key="ProjectExplorer.Target.ActiveRunConfiguration">0</value>
    <valuemap type="QVariantMap" key="ProjectExplorer.Target.BuildConfiguration.0">
     <value type="int" key="EnableQmlDebugging">0</value>
-    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory">/home/arvo/Faculdade/build-MangaManager-Qt5-Debug</value>
-    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory.shadowDir">/home/arvo/Faculdade/build-MangaManager-Qt5-Debug</value>
+    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory">/home/eduardo/build-MangaManager-Desktop-Debug</value>
+    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory.shadowDir">/home/eduardo/build-MangaManager-Desktop-Debug</value>
     <valuemap type="QVariantMap" key="ProjectExplorer.BuildConfiguration.BuildStepList.0">
      <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.0">
       <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
@@ -107,7 +110,7 @@
       <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
       <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.MakeStep</value>
      </valuemap>
-     <value type="qlonglong" key="ProjectExplorer.BuildStepList.StepsCount">2</value>
+     <value type="int" key="ProjectExplorer.BuildStepList.StepsCount">2</value>
      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Build</value>
      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Build</value>
      <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">ProjectExplorer.BuildSteps.Build</value>
@@ -118,7 +121,7 @@
       <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.MakeStep</value>
       <value type="QString" key="Qt4ProjectManager.MakeStep.MakeArguments">clean</value>
      </valuemap>
-     <value type="qlonglong" key="ProjectExplorer.BuildStepList.StepsCount">1</value>
+     <value type="int" key="ProjectExplorer.BuildStepList.StepsCount">1</value>
      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Clean</value>
      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Clean</value>
      <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">ProjectExplorer.BuildSteps.Clean</value>
@@ -133,8 +136,8 @@
     <value type="int" key="Qt4ProjectManager.Qt4BuildConfiguration.BuildConfiguration">2</value>
    </valuemap>
    <valuemap type="QVariantMap" key="ProjectExplorer.Target.BuildConfiguration.1">
-    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory">/home/arvo/Faculdade/build-MangaManager-Qt5-Release</value>
-    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory.shadowDir">/home/arvo/Faculdade/build-MangaManager-Qt5-Release</value>
+    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory">/home/eduardo/build-MangaManager-Desktop-Release</value>
+    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory.shadowDir">/home/eduardo/build-MangaManager-Desktop-Release</value>
     <valuemap type="QVariantMap" key="ProjectExplorer.BuildConfiguration.BuildStepList.0">
      <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.0">
       <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
@@ -146,7 +149,7 @@
       <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
       <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.MakeStep</value>
      </valuemap>
-     <value type="qlonglong" key="ProjectExplorer.BuildStepList.StepsCount">2</value>
+     <value type="int" key="ProjectExplorer.BuildStepList.StepsCount">2</value>
      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Build</value>
      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Build</value>
      <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">ProjectExplorer.BuildSteps.Build</value>
@@ -157,7 +160,7 @@
       <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.MakeStep</value>
       <value type="QString" key="Qt4ProjectManager.MakeStep.MakeArguments">clean</value>
      </valuemap>
-     <value type="qlonglong" key="ProjectExplorer.BuildStepList.StepsCount">1</value>
+     <value type="int" key="ProjectExplorer.BuildStepList.StepsCount">1</value>
      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Clean</value>
      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Clean</value>
      <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">ProjectExplorer.BuildSteps.Clean</value>
@@ -174,8 +177,8 @@
    </valuemap>
    <valuemap type="QVariantMap" key="ProjectExplorer.Target.BuildConfiguration.2">
     <value type="int" key="EnableQmlDebugging">0</value>
-    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory">/home/arvo/Faculdade/build-MangaManager-Qt5-Profile</value>
-    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory.shadowDir">/home/arvo/Faculdade/build-MangaManager-Qt5-Profile</value>
+    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory">/home/eduardo/build-MangaManager-Desktop-Profile</value>
+    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory.shadowDir">/home/eduardo/build-MangaManager-Desktop-Profile</value>
     <valuemap type="QVariantMap" key="ProjectExplorer.BuildConfiguration.BuildStepList.0">
      <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.0">
       <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
@@ -187,7 +190,7 @@
       <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
       <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.MakeStep</value>
      </valuemap>
-     <value type="qlonglong" key="ProjectExplorer.BuildStepList.StepsCount">2</value>
+     <value type="int" key="ProjectExplorer.BuildStepList.StepsCount">2</value>
      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Build</value>
      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Build</value>
      <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">ProjectExplorer.BuildSteps.Build</value>
@@ -198,7 +201,7 @@
       <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.MakeStep</value>
       <value type="QString" key="Qt4ProjectManager.MakeStep.MakeArguments">clean</value>
      </valuemap>
-     <value type="qlonglong" key="ProjectExplorer.BuildStepList.StepsCount">1</value>
+     <value type="int" key="ProjectExplorer.BuildStepList.StepsCount">1</value>
      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Clean</value>
      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Clean</value>
      <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">ProjectExplorer.BuildSteps.Clean</value>
@@ -214,10 +217,10 @@
     <value type="int" key="QtQuickCompiler">0</value>
     <value type="int" key="SeparateDebugInfo">0</value>
    </valuemap>
-   <value type="qlonglong" key="ProjectExplorer.Target.BuildConfigurationCount">3</value>
+   <value type="int" key="ProjectExplorer.Target.BuildConfigurationCount">3</value>
    <valuemap type="QVariantMap" key="ProjectExplorer.Target.DeployConfiguration.0">
     <valuemap type="QVariantMap" key="ProjectExplorer.BuildConfiguration.BuildStepList.0">
-     <value type="qlonglong" key="ProjectExplorer.BuildStepList.StepsCount">0</value>
+     <value type="int" key="ProjectExplorer.BuildStepList.StepsCount">0</value>
      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Deploy</value>
      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Deploy</value>
      <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">ProjectExplorer.BuildSteps.Deploy</value>
@@ -227,7 +230,7 @@
     <value type="bool" key="ProjectExplorer.DeployConfiguration.CustomDataEnabled">false</value>
     <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">ProjectExplorer.DefaultDeployConfiguration</value>
    </valuemap>
-   <value type="qlonglong" key="ProjectExplorer.Target.DeployConfigurationCount">1</value>
+   <value type="int" key="ProjectExplorer.Target.DeployConfigurationCount">1</value>
    <valuemap type="QVariantMap" key="ProjectExplorer.Target.RunConfiguration.0">
     <value type="bool" key="Analyzer.Perf.Settings.UseGlobalSettings">true</value>
     <value type="bool" key="Analyzer.QmlProfiler.Settings.UseGlobalSettings">true</value>
@@ -235,21 +238,21 @@
     <valuelist type="QVariantList" key="CustomOutputParsers"/>
     <value type="int" key="PE.EnvironmentAspect.Base">2</value>
     <valuelist type="QVariantList" key="PE.EnvironmentAspect.Changes"/>
-    <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.Qt4RunConfiguration:/home/arvo/Faculdade/Manga-Manager/MangaManager.pro</value>
-    <value type="QString" key="ProjectExplorer.RunConfiguration.BuildKey">/home/arvo/Faculdade/Manga-Manager/MangaManager.pro</value>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.Qt4RunConfiguration:/home/eduardo/MangaManager/MangaManager.pro</value>
+    <value type="QString" key="ProjectExplorer.RunConfiguration.BuildKey">/home/eduardo/MangaManager/MangaManager.pro</value>
     <value type="bool" key="RunConfiguration.UseCppDebugger">false</value>
     <value type="bool" key="RunConfiguration.UseCppDebuggerAuto">true</value>
     <value type="bool" key="RunConfiguration.UseLibrarySearchPath">true</value>
     <value type="bool" key="RunConfiguration.UseQmlDebugger">false</value>
     <value type="bool" key="RunConfiguration.UseQmlDebuggerAuto">true</value>
-    <value type="QString" key="RunConfiguration.WorkingDirectory.default">/home/arvo/Faculdade/build-MangaManager-Qt5-Debug</value>
+    <value type="QString" key="RunConfiguration.WorkingDirectory.default">/home/eduardo/build-MangaManager-Desktop-Debug</value>
    </valuemap>
-   <value type="qlonglong" key="ProjectExplorer.Target.RunConfigurationCount">1</value>
+   <value type="int" key="ProjectExplorer.Target.RunConfigurationCount">1</value>
   </valuemap>
  </data>
  <data>
   <variable>ProjectExplorer.Project.TargetCount</variable>
-  <value type="qlonglong">1</value>
+  <value type="int">1</value>
  </data>
  <data>
   <variable>ProjectExplorer.Project.Updater.FileVersion</variable>

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -167,3 +167,8 @@ void MainWindow::updateMangaCount() {
     int count = mangaManager->getPrimaryIndicesSize();
     ui->label->setText(QString("Total de mangás catalogados: %1").arg(count));
 }
+
+void MainWindow::onSearchMangaButtonClicked(){
+    QItemSelectionModel *selectionModel = ui->mangaTableView->selectionModel();
+    selectionModel->ClearAndSelect()
+}

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -4,6 +4,7 @@
 #include <QMainWindow>
 #include <QStandardItemModel>
 #include "addmangadialog.h"
+#include "searchmangadialog.h"
 #include "mangamanager.h"
 
 QT_BEGIN_NAMESPACE
@@ -22,11 +23,13 @@ private slots:
     void onAddMangaButtonClicked();
     void onEditMangaButtonClicked();
     void onRemoveMangaButtonClicked();
+    void onSearchMangaButtonClicked();
     void onMangaTableViewSelectionChanged();
 
 private:
     Ui::MainWindow *ui;
     AddMangaDialog *addMangaDialog;
+    searchMangaDialog *searchMangaDialog;
     MangaManager *mangaManager;
     QStandardItemModel *model;
 

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -93,7 +93,6 @@
          <font>
           <family>Ani</family>
           <pointsize>36</pointsize>
-          <weight>75</weight>
           <bold>true</bold>
          </font>
         </property>
@@ -114,7 +113,6 @@
          <font>
           <family>Ani</family>
           <pointsize>34</pointsize>
-          <weight>75</weight>
           <bold>true</bold>
          </font>
         </property>
@@ -212,7 +210,6 @@
          <font>
           <family>Ubuntu</family>
           <pointsize>14</pointsize>
-          <weight>50</weight>
           <bold>false</bold>
          </font>
         </property>
@@ -226,6 +223,19 @@
          <string>Total de mangás catalogados: </string>
         </property>
        </widget>
+       <widget class="QPushButton" name="search_manga_button">
+        <property name="geometry">
+         <rect>
+          <x>640</x>
+          <y>460</y>
+          <width>91</width>
+          <height>31</height>
+         </rect>
+        </property>
+        <property name="text">
+         <string>Buscar</string>
+        </property>
+       </widget>
       </widget>
      </item>
     </layout>
@@ -237,7 +247,7 @@
      <x>0</x>
      <y>0</y>
      <width>1236</width>
-     <height>22</height>
+     <height>19</height>
     </rect>
    </property>
   </widget>

--- a/mangamanager.cpp
+++ b/mangamanager.cpp
@@ -7,6 +7,7 @@
 MangaManager::MangaManager(const QString &basePath) {
     dataFileName = basePath + "/manga_data.txt";
     indexFileName = basePath + "/manga_index.txt";
+    secondaryIndexFileName = basePath + "/manga_secondary_index.txt";
     loadIndices();
     qDebug() << "MangaManager initialized with data file:" << dataFileName << "and index file:" << indexFileName;
 }
@@ -25,6 +26,21 @@ void MangaManager::addManga(const Manga &manga) {
     } else {
         qDebug() << "Failed to open data file for appending";
     }
+}
+
+Manga MangaManger::getMangaByTitle(const QString &mangaTitle){
+    QFile secondaryIndexFile(secondaryIndexFileName);
+    Manga manga;
+    if (secondaryIndexFile.open(QIODevice::ReadOnly | QIODevice::Text)) {
+        QTextStream in(&secondaryIndexFile);
+        in.setCodec("UTF-8");
+        /* se o arquivo contém uma linha com <título - índice>:
+         * umIndice = leIndice();
+         * manga = getMangaByIndex();
+         * */
+    }
+    return manga;
+
 }
 
 Manga MangaManager::getMangaByIndex(int index) {

--- a/searchmangadialog.cpp
+++ b/searchmangadialog.cpp
@@ -1,0 +1,26 @@
+#include "searchmangadialog.h"
+
+SearchMangaDialog::SearchMangaDialog(QWidget *parent)
+    : QDialog(parent) {
+    setWindowTitle("Buscar Mangá");
+
+    titleEdit = new QLineEdit(this);
+
+    searchButton = new QPushButton("Buscar", this);
+
+    QFormLayout *formLayout = new QFormLayout;
+    formLayout->addRow("Título:", titleEdit);
+
+    QVBoxLayout *mainLayout = new QVBoxLayout;
+    mainLayout->addLayout(formLayout);
+    mainLayout->addWidget(searchButton);
+
+    setLayout(mainLayout);
+
+    connect(searchButton, &QPushButton::clicked, this, &SearchMangaDialog::onSaveButtonClicked);
+}
+
+void SearchMangaDialog::onSaveButtonClicked() {
+    // Implementar funcionalidade de salvar mangá
+    accept();
+}

--- a/searchmangadialog.h
+++ b/searchmangadialog.h
@@ -1,0 +1,21 @@
+#ifndef SEARCHMANGADIALOG_H
+#define SEARCHMANGADIALOG_H
+
+#include <QDialog>
+#include <QLineEdit>
+#include <QPushButton>
+#include <QFormLayout>
+#include <QVBoxLayout>
+
+class SearchMangaDialog : public QDialog {
+    Q_OBJECT
+
+public:
+    SearchMangaDialog(QWidget *parent = nullptr);
+    QLineEdit* getTitleEdit() const { return titleEdit; }
+private slots:
+    void onSaveButtonClicked();
+private:
+     QLineEdit *titleEdit;
+#endif // SEARCHMANGADIALOG_H
+


### PR DESCRIPTION
Ainda não está funcional. 
A ideia é criar mais um arquivo chamado "manga_secondary_index.txt", que possui a seguinte estrutura:
<título em ordem alfabética - índice do mangá no arquivo de índices/n>
Quando o botão de busca que eu adicionei é clicado, ele deve fazer uma busca binária pelo título do mangá nesse arquivo de índices e retornar o índice do mangá no arquivo de índice e, por sua vez, selecionar na interface de usuário o mangá buscado.
Qualquer dúvida pode me chamar.
Não dê merge sem testar, por favor.